### PR TITLE
prevent player from moving while they are ADS and prone at the same time

### DIFF
--- a/packages/frontend/src/game/player/controls/move.ts
+++ b/packages/frontend/src/game/player/controls/move.ts
@@ -21,6 +21,7 @@ export const move = (props: UseMoveProps) => {
         // TODO: Better deadzone handling
         Math.abs(angle) < 0.1 ? 0 : angle,
     );
+
     if (leftX == null || leftY == null || rightX == null || rightY == null) {
         return;
     }
@@ -55,6 +56,9 @@ export const move = (props: UseMoveProps) => {
 
     // Cut movement speed into a quarter when prone (this stacks with crouching)
     if (playerRef.isProne) moveSpeedDelta /= 4;
+
+    // Prevent player from moving if they ADS while prone
+    if (playerRef.isProne && playerRef.isAiming) moveSpeedDelta = 0;
 
     props.playerVelocity.add(
         getSideVector(props.camera, props.playerDirection).multiplyScalar(moveSpeedDelta * leftX),

--- a/packages/frontend/src/game/weapons/animations/ads.ts
+++ b/packages/frontend/src/game/weapons/animations/ads.ts
@@ -27,7 +27,7 @@ export const ads = (props: ApplyADSProps) => {
     props.group.translateZ(props.adsOffset.z);
 
     // If the player is walking while aiming, apply a sway effect
-    if (props.playerIsWalking) {
+    if (props.playerIsWalking && props.walkingSpeed > 0) {
         const adsWalkingAmplitude = 0.003; // Adjust the amplitude to control sway intensity
         const { x, y } = walkCoordinates({
             amplitude: adsWalkingAmplitude,

--- a/packages/frontend/src/game/weapons/animations/crawl.ts
+++ b/packages/frontend/src/game/weapons/animations/crawl.ts
@@ -1,0 +1,16 @@
+import { Vector3 } from "three";
+import type { Clock, Group } from "three";
+
+interface CrawlProps {
+    clock: Clock;
+    group: Group;
+    idleOffset: Vector3;
+    idleRotation: Vector3;
+    walkingSpeed: number;
+}
+
+export const crawl = (props: CrawlProps) => {
+    const { clock, group, idleOffset, idleRotation, walkingSpeed } = props;
+};
+
+const crawlCoordinates = () => {};

--- a/packages/frontend/src/game/weapons/animations/functions/handleWalkingSpeed.ts
+++ b/packages/frontend/src/game/weapons/animations/functions/handleWalkingSpeed.ts
@@ -19,5 +19,8 @@ export const handleWalkingSpeed = (playerRef: PlayerState, leftX: number, leftY:
     // Cut movement speed in half when aiming
     if (playerRef.isAiming) walkingSpeed /= 2;
 
+    // Stop player from moving if they ADS while prone
+    if (playerRef.isProne && playerRef.isAiming) walkingSpeed = 0;
+
     return walkingSpeed;
 };

--- a/packages/frontend/src/game/weapons/animations/hooks/useWeaponAnimations.ts
+++ b/packages/frontend/src/game/weapons/animations/hooks/useWeaponAnimations.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { ads } from "../ads";
+import { crawl } from "../crawl";
 import { idle } from "../idle";
 import { handleWalkingSpeed } from "../functions/handleWalkingSpeed";
 import { sprint } from "../sprint";
@@ -106,7 +107,13 @@ export const useWeaponAnimations = (props: WeaponAnimationProps) => {
         }
 
         if (playerRef.isProne) {
-            // Do something here
+            crawl({
+                clock,
+                group: props.group.current,
+                idleOffset: props.idleOffset,
+                idleRotation: props.idleRotation,
+                walkingSpeed,
+            });
         }
 
         if (playerIsWalking) {


### PR DESCRIPTION
### Description

Prevents the player from moving if they are aiming while also laying down

### ClickUp Tickets

[https://app.clickup.com/t/86b3b4kak](https://app.clickup.com/t/86b3b4kak)

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
